### PR TITLE
Upgraded to vert.x 4.5.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <clojure.version>1.10.3</clojure.version>
     <clojure.plugin.version>1.8.4</clojure.plugin.version>
     <junit.version>4.13</junit.version>
-    <stack.version>4.1.0</stack.version>
+    <stack.version>4.5.7</stack.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx-lang-clojure-gen/pom.xml
+++ b/vertx-lang-clojure-gen/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>vertx-lang-clojure-gen</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.5.7</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>4.1.0</version>
+      <version>4.5.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -246,7 +246,7 @@
               </includeArtifactIds>
               <classifier>sources</classifier>
               <!-- Prevent AuthOptions (interface) to be generated with ctor -->
-              <excludes>**/impl/**/*.java,io/vertx/groovy/**,io/vertx/reactivex/**,io/vertx/rxjava/**,examples/override/**,io/vertx/codegen/testmodel/**,io/vertx/ext/auth/AuthOptions.java</excludes>
+              <excludes>**/impl/**/*.java,io/vertx/ext/web/handler/OtpAuthHandler.java,examples/**,io/vertx/groovy/**,io/vertx/reactivex/**,io/vertx/rxjava/**,examples/override/**,io/vertx/codegen/testmodel/**,io/vertx/ext/auth/AuthOptions.java</excludes>
               <outputDirectory>${project.build.directory}/sources/vertx-core</outputDirectory>
             </configuration>
           </execution>

--- a/vertx-lang-clojure/pom.xml
+++ b/vertx-lang-clojure/pom.xml
@@ -12,7 +12,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-clojure</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.5.7</version>
 
   <properties>
     <log4j.version>1.2.17</log4j.version>

--- a/vertx-lang-clojure/src/main/java/io/vertx/lang/clojure/ClojureDocGenerator.java
+++ b/vertx-lang-clojure/src/main/java/io/vertx/lang/clojure/ClojureDocGenerator.java
@@ -1,6 +1,6 @@
 package io.vertx.lang.clojure;
 
-import io.vertx.docgen.Coordinate;
+//import io.vertx.docgen.Coordinate;
 import io.vertx.docgen.DocGenerator;
 import io.vertx.docgen.JavaDocGenerator;
 
@@ -41,18 +41,18 @@ public class ClojureDocGenerator implements DocGenerator {
     }
 
     @Override
-    public String resolveTypeLink(TypeElement elt, Coordinate coordinate) {
-        return javaGen.resolveTypeLink(elt, coordinate);
+    public String resolveTypeLink(TypeElement elt) {
+        return javaGen.resolveTypeLink(elt);
     }
 
     @Override
-    public String resolveConstructorLink(ExecutableElement elt, Coordinate coordinate) {
-        return javaGen.resolveConstructorLink(elt, coordinate);
+    public String resolveConstructorLink(ExecutableElement elt) {
+        return javaGen.resolveConstructorLink(elt);
     }
 
     @Override
-    public String resolveMethodLink(ExecutableElement elt, Coordinate coordinate) {
-        return javaGen.resolveMethodLink(elt, coordinate);
+    public String resolveMethodLink(ExecutableElement elt) {
+        return javaGen.resolveMethodLink(elt);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class ClojureDocGenerator implements DocGenerator {
     }
 
     @Override
-    public String resolveFieldLink(VariableElement elt, Coordinate coordinate) {
-        return javaGen.resolveFieldLink(elt, coordinate);
+    public String resolveFieldLink(VariableElement elt) {
+        return javaGen.resolveFieldLink(elt);
     }
 }


### PR DESCRIPTION
Upgraded to vert.x 4.5.7 with bug fixes. 

Excluded several .java source files that report errors, which did not belong to vertx-core.